### PR TITLE
Import dienstverbanden en abonnementen toegevoegd

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Op dit moment worden de volgende url's afgevangen:
 | /tijdschrijven/projecten                 | Projecten raadplegen  |
 | /tijdschrijven/project/create/           | Project aanmaken      |
 | /tijdschrijven/project/<int:pk>/update/  | Project wijzigen      |
-| /tijdschrijven/ project/<int:pk>/delete/ | Project verwijderen   |
+| /tijdschrijven/project/<int:pk>/delete/  | Project verwijderen   |
 | /tijdschrijven/abonnementen              | Toon abonnementen     |
 | /tijdschrijven/abonnement/create/        | Abonnement toevoegen  |
 | /tijdschrijven/urenschrijven             | Uren schrijven        |

--- a/README.md
+++ b/README.md
@@ -4,9 +4,18 @@
 In deze repository houden we de code voor het Django project TimeFox bij. Dit project bevat de online registratie van uren.
 
 # Afgevangen URLS
-```
-Weergave welke urls worden afgevangen (zie urls.py)
-```
+
+Op dit moment worden de volgende url's afgevangen:
+| Url                                      | Pagina                |
+| ---------------------------------------- |-----------------------|
+| /tijdschrijven/                          | Indexpagina           |
+| /tijdschrijven/projecten                 | Projecten raadplegen  |
+| /tijdschrijven/project/create/           | Project aanmaken      |
+| /tijdschrijven/project/<int:pk>/update/  | Project wijzigen      |
+| /tijdschrijven/ project/<int:pk>/delete/ | Project verwijderen   |
+| /tijdschrijven/abonnementen              | Toon abonnementen     |
+| /tijdschrijven/abonnement/create/        | Abonnement toevoegen  |
+| /tijdschrijven/urenschrijven             | Uren schrijven        |
 
 # Apps
 
@@ -14,10 +23,12 @@ Overzicht van de apps die onder dit Django project vallen
 * Tijdschrijven
 
 ### Tijdschrijven
-De app tijdschrijven zorgt voor de registratie van uren. 
-```
-datamodel hier nog uitwerken
-```
+De app tijdschrijven zorgt voor de registratie van uren. In de app zijn de volgende datamodellen uitgewerkt:
+* Project -> De projecten waarop geschreven wordt
+* Persoon -> De personen die tijd kunnen schrijven. Een aanvulling op de Django user-klasse
+* Abonnement -> Koppeling van projecten aan personen. Op welke projecten mag men schrijven
+* ProjectTemplate -> Templates van activiteiten voor de diverse soorten projecten
+* GeschrevenTijd -> De geschreven uren
 
 # Gebruikte packages
 
@@ -48,6 +59,7 @@ We hebben de volgende logging geconfigureerd:
 
 * database (lokaal: sqlite3, server: postgres)
 * migration mappen (match tussen db en project)
+* settings.ini voor de toekenning van de variabelen: SECRET_KEY, DEBUG, ALLOWED_HOSTS, DB_ENGINE, DB_NAME, DB_USER, DB_PASSWORD, DB_HOST, DB_PORT,EMAIL_BACKEND)
 
 
 

--- a/tijdschrijven/management/commands/load_model_data.py
+++ b/tijdschrijven/management/commands/load_model_data.py
@@ -2,7 +2,7 @@ from csv import DictReader
 
 from django.core.management import BaseCommand
 
-from tijdschrijven.models import Project, Persoon
+from tijdschrijven.models import Project, Persoon, Abonnement
 from django.contrib.auth.models import User
 from django.contrib.auth import get_user_model
 
@@ -39,9 +39,18 @@ class Command(BaseCommand):
             gebruiker.is_superuser= row['Superuser']
             gebruiker.is_staff= row['Staff']
             gebruiker.save()
+            # aanvullen dienstverbanden
             persoon = Persoon.objects.get(user=gebruiker)
             persoon.Dienstverband=row['Uren']
             persoon.save()
+            # toevoegen abonnementen
+            projecten = Project.objects.all()
+            for project in projecten:
+                abonnement = Abonnement()
+                abonnement.ProjectID=project
+                abonnement.PersoonID=persoon
+                abonnement.OriginalObjectID=project.id
+                abonnement.save()
         print("Gebruikers toegevoegd.")
         print("Het script is volledig uitgevoerd.")
         

--- a/tijdschrijven/management/commands/load_model_data.py
+++ b/tijdschrijven/management/commands/load_model_data.py
@@ -2,7 +2,7 @@ from csv import DictReader
 
 from django.core.management import BaseCommand
 
-from tijdschrijven.models import Project
+from tijdschrijven.models import Project, Persoon
 from django.contrib.auth.models import User
 from django.contrib.auth import get_user_model
 
@@ -31,14 +31,17 @@ class Command(BaseCommand):
        
         print("Toevoegen gebruikers....")
         
-        for row2 in DictReader(open('./user_data.csv')):
-            gebruiker = User.objects.create_user(row2['Medewerker'], password=row2['Password'])
-            gebruiker.first_name = row2['First']
-            gebruiker.last_name = row2['Last']
-            gebruiker.is_active = row2['Active']
-            gebruiker.is_superuser= row2['Superuser']
-            gebruiker.is_staff= row2['Staff']
+        for row in DictReader(open('./user_data.csv')):
+            gebruiker = User.objects.create_user(row['Medewerker'], password=row['Password'])
+            gebruiker.first_name = row['First']
+            gebruiker.last_name = row['Last']
+            gebruiker.is_active = row['Active']
+            gebruiker.is_superuser= row['Superuser']
+            gebruiker.is_staff= row['Staff']
             gebruiker.save()
+            persoon = Persoon.objects.get(user=gebruiker)
+            persoon.Dienstverband=row['Uren']
+            persoon.save()
         print("Gebruikers toegevoegd.")
         print("Het script is volledig uitgevoerd.")
         

--- a/user_data.csv
+++ b/user_data.csv
@@ -1,7 +1,7 @@
-﻿Regel,Medewerker,First,Last,Password,Active,Superuser,Staff
-1,superuser,Super,User,Timefox1,True,True,False
-2,gebruiker1,Pietje,Puk,Timefox1,True,False,False
-3,gebruiker2,Jan,Met de Pet,Timefox1,True,False,False
-4,gebruiker3,Frits,Fritsen,Timefox1,True,False,False
-5,gebruiker4,Bassie,van Adriaan,Timefox1,True,False,False
-6,staff,Staf,Lid,Timefox1,True,False,True
+﻿Regel,Medewerker,First,Last,Password,Active,Superuser,Staff,Uren
+1,superuser,Super,User,Timefox1,True,True,True,40
+2,gebruiker1,Pietje,Puk,Timefox1,True,False,False,40
+3,gebruiker2,Jan,Met de Pet,Timefox1,True,False,False,32
+4,gebruiker3,Frits,Fritsen,Timefox1,True,False,False,28
+5,gebruiker4,Bassie,van Adriaan,Timefox1,True,False,False,40
+6,staff,Staf,Lid,Timefox1,True,False,True,24


### PR DESCRIPTION
Hey MacMaxim,

Ik heb de import nu werkend op de dienstverbanden en de abonnementen. Bij de abonnementen heb ik gekozen voor de snelle variant. Alle medewerkers krijgen alle projecten. Dat zorgt voor voldoende testdata.

Verder heb ik de documentatie (README.MD) bijgewerkt.